### PR TITLE
Add CI workflow for Kotlin Multiplatform build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: |
+            platform-tools
+            platforms;android-36
+            build-tools;35.0.0
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build project
+        run: ./gradlew build --stacktrace


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs on pushes to main and pull requests
- configure Temurin JDK 17, install the required Android SDK components, and build the project via Gradle

## Testing
- ./gradlew build *(fails locally: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc71e4fd2c8328b88592fb1bb60233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a continuous integration workflow that triggers on pushes to main and on pull requests. It runs on Linux, checks out the repository, configures JDK 17 (Temurin) with Gradle caching, sets up the Android SDK, ensures Gradle wrapper execution, and runs the Gradle build with detailed stack traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->