### PR TITLE
Configure compose app dependencies in build logic

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,0 +1,33 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    `kotlin-dsl`
+}
+
+group = "my.id.tasius.dailysleeptracker.buildlogic"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    compileOnly(libs.android.gradle)
+    compileOnly(libs.kotlin.gradle)
+    compileOnly(libs.compose.gradlePlugin)
+}
+
+gradlePlugin {
+    plugins {
+        register("composeAppConvention") {
+            id = "dailysleeptracker.composeapp"
+            implementationClass = "my.id.tasius.dailysleeptracker.buildlogic.ComposeAppConventionPlugin"
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/my/id/tasius/dailysleeptracker/buildlogic/ComposeAppConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/my/id/tasius/dailysleeptracker/buildlogic/ComposeAppConventionPlugin.kt
@@ -1,0 +1,161 @@
+package my.id.tasius.dailysleeptracker.buildlogic
+
+import com.android.build.api.dsl.ApplicationExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.provider.Provider
+import org.gradle.kotlin.dsl.DependencyHandlerScope
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.jetbrains.compose.ComposeExtension
+import org.jetbrains.compose.ComposePlugin
+import org.jetbrains.compose.ExperimentalComposeLibrary
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+class ComposeAppConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply {
+            apply("com.android.application")
+            apply("org.jetbrains.kotlin.multiplatform")
+            apply("org.jetbrains.compose")
+            apply("org.jetbrains.kotlin.plugin.compose")
+            apply("org.jetbrains.kotlin.plugin.serialization")
+        }
+
+        configureKotlinMultiplatform()
+        configureAndroidApplication()
+        configureComposeAppDependencies()
+    }
+}
+
+private fun Project.configureKotlinMultiplatform() {
+    extensions.configure<KotlinMultiplatformExtension> {
+        applyDefaultHierarchyTemplate()
+
+        androidTarget {
+            compilerOptions {
+                jvmTarget.set(JvmTarget.JVM_11)
+            }
+        }
+
+        listOf(
+            iosArm64(),
+            iosSimulatorArm64(),
+        ).forEach { iosTarget ->
+            iosTarget.binaries.framework {
+                baseName = "ComposeApp"
+                isStatic = true
+            }
+        }
+    }
+}
+
+private fun Project.configureAndroidApplication() {
+    extensions.configure<ApplicationExtension> {
+        val compileSdkVersion = versionInt("android-compileSdk")
+        val minSdkVersion = versionInt("android-minSdk")
+        val targetSdkVersion = versionInt("android-targetSdk")
+
+        compileSdk = compileSdkVersion
+        defaultConfig {
+            minSdk = minSdkVersion
+            targetSdk = targetSdkVersion
+        }
+
+        packaging.resources.excludes += "/META-INF/{AL2.0,LGPL2.1}"
+
+        compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_11
+            targetCompatibility = JavaVersion.VERSION_11
+        }
+    }
+}
+
+private fun Project.versionInt(key: String): Int =
+    libs.findVersion(key).orElseThrow {
+        IllegalArgumentException("Version '$key' is not defined in the version catalog.")
+    }.requiredVersion.toInt()
+
+private fun Project.configureComposeAppDependencies() {
+    val composeExtension = extensions.getByName("compose") as ComposeExtension
+    val composeDependencies = composeExtension.dependencies
+    val libs = libs
+
+    dependencies {
+        addCoreDependencies(composeDependencies, libs)
+        addFeatureDependencies(libs)
+        addSupportingDependencies(libs)
+
+        androidMainImplementation(composeDependencies.preview)
+        androidMainImplementation(libs.requireLibrary("androidx.activity.compose"))
+        androidMainImplementation(libs.requireLibrary("ktor.client.okhttp"))
+
+        iosMainImplementation(libs.requireLibrary("ktor.client.darwin"))
+
+        commonTestImplementation(libs.requireLibrary("kotlin.test"))
+
+        debugImplementation(composeDependencies.uiTooling)
+    }
+}
+
+@OptIn(ExperimentalComposeLibrary::class)
+private fun DependencyHandlerScope.addCoreDependencies(
+    composeDependencies: ComposePlugin.Dependencies,
+    libs: VersionCatalog,
+) {
+    commonMainImplementation(composeDependencies.runtime)
+    commonMainImplementation(composeDependencies.foundation)
+    commonMainImplementation(composeDependencies.material3)
+    commonMainImplementation(composeDependencies.ui)
+    commonMainImplementation(composeDependencies.components.resources)
+    commonMainImplementation(composeDependencies.components.uiToolingPreview)
+    commonMainImplementation(libs.requireLibrary("androidx.lifecycle.viewmodelCompose"))
+    commonMainImplementation(libs.requireLibrary("androidx.lifecycle.runtimeCompose"))
+    commonMainImplementation(libs.requireLibrary("kotlinx.serialization.json"))
+}
+
+private fun DependencyHandlerScope.addFeatureDependencies(libs: VersionCatalog) {
+    commonMainImplementation(libs.requireLibrary("koin.core"))
+    commonMainImplementation(libs.requireLibrary("koin.androidx.compose"))
+    commonMainImplementation(libs.requireLibrary("androidx.navigation.compose"))
+}
+
+private fun DependencyHandlerScope.addSupportingDependencies(libs: VersionCatalog) {
+    commonMainImplementation(libs.requireLibrary("coil.compose"))
+    commonMainImplementation(libs.requireLibrary("coil.network.ktor3"))
+    commonMainImplementation(libs.requireLibrary("ktor.client.core"))
+    commonMainImplementation(libs.requireLibrary("ktor.serialization.kotlinx.json"))
+    commonMainImplementation(libs.requireLibrary("ktor.client.content.negotiation"))
+    commonMainImplementation(libs.requireLibrary("ktor.client.mock"))
+    commonMainImplementation(libs.requireLibrary("androidx.datastore"))
+    commonMainImplementation(libs.requireLibrary("androidx.datastore.preferences"))
+}
+
+private fun VersionCatalog.requireLibrary(alias: String): Provider<MinimalExternalModuleDependency> =
+    findLibrary(alias).orElseThrow {
+        IllegalArgumentException("Library '$alias' is not defined in the version catalog.")
+    }
+
+private fun DependencyHandlerScope.commonMainImplementation(dependency: Any) {
+    add("commonMainImplementation", dependency)
+}
+
+private fun DependencyHandlerScope.androidMainImplementation(dependency: Any) {
+    add("androidMainImplementation", dependency)
+}
+
+private fun DependencyHandlerScope.iosMainImplementation(dependency: Any) {
+    add("iosMainImplementation", dependency)
+}
+
+private fun DependencyHandlerScope.commonTestImplementation(dependency: Any) {
+    add("commonTestImplementation", dependency)
+}
+
+private fun DependencyHandlerScope.debugImplementation(dependency: Any) {
+    add("debugImplementation", dependency)
+}

--- a/build-logic/convention/src/main/kotlin/my/id/tasius/dailysleeptracker/buildlogic/ProjectExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/my/id/tasius/dailysleeptracker/buildlogic/ProjectExtensions.kt
@@ -1,0 +1,9 @@
+package my.id.tasius.dailysleeptracker.buildlogic
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
+
+val Project.libs: VersionCatalog
+    get() = extensions.getByType<VersionCatalogsExtension>().named("libs")

--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -1,0 +1,3 @@
+# Gradle properties for the included build-logic project.
+org.gradle.parallel=true
+org.gradle.caching=true

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,28 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
+        mavenCentral()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"
+include(":convention")

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,110 +1,17 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidApplication)
-    alias(libs.plugins.composeMultiplatform)
-    alias(libs.plugins.composeCompiler)
-    alias(libs.plugins.kotlin.serialization)
-}
-
-kotlin {
-    androidTarget {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_11)
-        }
-    }
-    
-    listOf(
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach { iosTarget ->
-        iosTarget.binaries.framework {
-            baseName = "ComposeApp"
-            isStatic = true
-        }
-    }
-    
-    sourceSets {
-        androidMain.dependencies {
-            implementation(compose.preview)
-            implementation(libs.androidx.activity.compose)
-            implementation(libs.ktor.client.okhttp)
-        }
-        commonMain.dependencies {
-            implementation(compose.runtime)
-            implementation(compose.foundation)
-            implementation(compose.material3)
-            implementation(compose.ui)
-            implementation(compose.components.resources)
-            implementation(compose.components.uiToolingPreview)
-            implementation(libs.androidx.lifecycle.viewmodelCompose)
-            implementation(libs.androidx.lifecycle.runtimeCompose)
-            implementation(libs.kotlinx.serialization.json)
-
-            // KOIN
-            implementation(libs.koin.core)
-            implementation(libs.koin.androidx.compose)
-            implementation(libs.androidx.navigation.compose)
-
-            // COIL
-            implementation(libs.coil.compose)
-            implementation(libs.coil.network.ktor3)
-
-            // Core Ktor
-            implementation(libs.ktor.client.core)
-
-            // JSON serialization
-            implementation(libs.ktor.serialization.kotlinx.json)
-
-            // Content negotiation for JSON
-            implementation(libs.ktor.client.content.negotiation)
-
-            // For testing and mocking HTTP
-            implementation(libs.ktor.client.mock)
-
-            // DataStore library
-            implementation(libs.androidx.datastore)
-
-            // The Preferences DataStore library
-            implementation(libs.androidx.datastore.preferences)
-        }
-        iosMain.dependencies {
-            implementation(libs.ktor.client.darwin)
-        }
-        commonTest.dependencies {
-            implementation(libs.kotlin.test)
-        }
-    }
+    alias(libs.plugins.dailysleeptracker.composeapp)
 }
 
 android {
     namespace = "my.id.tasius.dailysleeptracker"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
-
     defaultConfig {
         applicationId = "my.id.tasius.dailysleeptracker"
-        minSdk = libs.versions.android.minSdk.get().toInt()
-        targetSdk = libs.versions.android.targetSdk.get().toInt()
         versionCode = 1
         versionName = "1.0"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
     }
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
         }
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-}
-
-dependencies {
-    debugImplementation(compose.uiTooling)
 }

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@android:style/Theme.Material.Light.NoActionBar">
+        android:theme="@style/Theme.DailySleepTracker">
         <activity
             android:exported="true"
             android:name=".MainActivity">

--- a/composeApp/src/main/res/values/themes.xml
+++ b/composeApp/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.DailySleepTracker" parent="android:Theme.Material.Light.NoActionBar.Fullscreen">
+        <item name="android:windowIsTranslucent">true</item>
+    </style>
+</resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ kotlinxSerializationJson = "1.9.0"
 
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "datastorePreferences" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
+android-gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -53,6 +54,8 @@ ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 
+compose-gradlePlugin = { module = "org.jetbrains.compose:org.jetbrains.compose.gradle.plugin", version.ref = "composeMultiplatform" }
+
 #Coroutines
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 
@@ -68,3 +71,4 @@ composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "k
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+dailysleeptracker-composeapp = { id = "dailysleeptracker.composeapp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,3 +29,4 @@ dependencyResolutionManagement {
 }
 
 include(":composeApp")
+includeBuild("build-logic")


### PR DESCRIPTION
## Summary
- wire compose, feature, and supporting dependencies through the compose app convention plugin
- slim the composeApp module script so it delegates dependency management to build logic
- add the Compose Gradle plugin artifact to the build-logic classpath via the version catalog

## Testing
- ./gradlew --console=plain :composeApp:tasks --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68dcabd78d948328b61f905b4e085933

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Centralized build configuration into a reusable convention to simplify module build scripts and tooling.
- Chores
  - Enabled Gradle parallel builds and caching.
  - Integrated shared build logic via an included composite build and updated version catalog entries.
  - Standardized toolchains to Java/Kotlin 17.
- UI
  - App theme updated to a new translucent fullscreen theme (Theme.DailySleepTracker).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->