### PR TITLE
Split build logic into reusable convention plugins

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -29,5 +29,13 @@ gradlePlugin {
             id = "dailysleeptracker.composeapp"
             implementationClass = "my.id.tasius.dailysleeptracker.buildlogic.ComposeAppConventionPlugin"
         }
+        register("featureConvention") {
+            id = "dailysleeptracker.feature"
+            implementationClass = "my.id.tasius.dailysleeptracker.buildlogic.FeatureConventionPlugin"
+        }
+        register("coreConvention") {
+            id = "dailysleeptracker.core"
+            implementationClass = "my.id.tasius.dailysleeptracker.buildlogic.CoreConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/my/id/tasius/dailysleeptracker/buildlogic/ComposeAppConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/my/id/tasius/dailysleeptracker/buildlogic/ComposeAppConventionPlugin.kt
@@ -1,20 +1,11 @@
 package my.id.tasius.dailysleeptracker.buildlogic
 
 import com.android.build.api.dsl.ApplicationExtension
-import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.MinimalExternalModuleDependency
-import org.gradle.api.artifacts.VersionCatalog
-import org.gradle.api.provider.Provider
-import org.gradle.kotlin.dsl.DependencyHandlerScope
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.jetbrains.compose.ComposeExtension
-import org.jetbrains.compose.ComposePlugin
-import org.jetbrains.compose.ExperimentalComposeLibrary
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 class ComposeAppConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
@@ -26,31 +17,9 @@ class ComposeAppConventionPlugin : Plugin<Project> {
             apply("org.jetbrains.kotlin.plugin.serialization")
         }
 
-        configureKotlinMultiplatform()
+        configureKotlinMultiplatform(frameworkName = "ComposeApp")
         configureAndroidApplication()
         configureComposeAppDependencies()
-    }
-}
-
-private fun Project.configureKotlinMultiplatform() {
-    extensions.configure<KotlinMultiplatformExtension> {
-        applyDefaultHierarchyTemplate()
-
-        androidTarget {
-            compilerOptions {
-                jvmTarget.set(JvmTarget.JVM_11)
-            }
-        }
-
-        listOf(
-            iosArm64(),
-            iosSimulatorArm64(),
-        ).forEach { iosTarget ->
-            iosTarget.binaries.framework {
-                baseName = "ComposeApp"
-                isStatic = true
-            }
-        }
     }
 }
 
@@ -68,17 +37,9 @@ private fun Project.configureAndroidApplication() {
 
         packaging.resources.excludes += "/META-INF/{AL2.0,LGPL2.1}"
 
-        compileOptions {
-            sourceCompatibility = JavaVersion.VERSION_11
-            targetCompatibility = JavaVersion.VERSION_11
-        }
+        configureAndroidCommonOptions()
     }
 }
-
-private fun Project.versionInt(key: String): Int =
-    libs.findVersion(key).orElseThrow {
-        IllegalArgumentException("Version '$key' is not defined in the version catalog.")
-    }.requiredVersion.toInt()
 
 private fun Project.configureComposeAppDependencies() {
     val composeExtension = extensions.getByName("compose") as ComposeExtension
@@ -86,76 +47,17 @@ private fun Project.configureComposeAppDependencies() {
     val libs = libs
 
     dependencies {
-        addCoreDependencies(composeDependencies, libs)
+        addComposeUiDependencies(composeDependencies, libs)
         addFeatureDependencies(libs)
-        addSupportingDependencies(libs)
+        addImageLoadingDependencies(libs)
+        addNetworkingDependencies(libs)
+        addDataStoreDependencies(libs)
+        addKoinComposeDependencies(libs)
 
         androidMainImplementation(composeDependencies.preview)
         androidMainImplementation(libs.requireLibrary("androidx.activity.compose"))
-        androidMainImplementation(libs.requireLibrary("ktor.client.okhttp"))
-
-        iosMainImplementation(libs.requireLibrary("ktor.client.darwin"))
-
-        commonTestImplementation(libs.requireLibrary("kotlin.test"))
-
         debugImplementation(composeDependencies.uiTooling)
+        addKotlinTestDependencies(libs)
+        addKtorPlatformDependencies(libs)
     }
-}
-
-@OptIn(ExperimentalComposeLibrary::class)
-private fun DependencyHandlerScope.addCoreDependencies(
-    composeDependencies: ComposePlugin.Dependencies,
-    libs: VersionCatalog,
-) {
-    commonMainImplementation(composeDependencies.runtime)
-    commonMainImplementation(composeDependencies.foundation)
-    commonMainImplementation(composeDependencies.material3)
-    commonMainImplementation(composeDependencies.ui)
-    commonMainImplementation(composeDependencies.components.resources)
-    commonMainImplementation(composeDependencies.components.uiToolingPreview)
-    commonMainImplementation(libs.requireLibrary("androidx.lifecycle.viewmodelCompose"))
-    commonMainImplementation(libs.requireLibrary("androidx.lifecycle.runtimeCompose"))
-    commonMainImplementation(libs.requireLibrary("kotlinx.serialization.json"))
-}
-
-private fun DependencyHandlerScope.addFeatureDependencies(libs: VersionCatalog) {
-    commonMainImplementation(libs.requireLibrary("koin.core"))
-    commonMainImplementation(libs.requireLibrary("koin.androidx.compose"))
-    commonMainImplementation(libs.requireLibrary("androidx.navigation.compose"))
-}
-
-private fun DependencyHandlerScope.addSupportingDependencies(libs: VersionCatalog) {
-    commonMainImplementation(libs.requireLibrary("coil.compose"))
-    commonMainImplementation(libs.requireLibrary("coil.network.ktor3"))
-    commonMainImplementation(libs.requireLibrary("ktor.client.core"))
-    commonMainImplementation(libs.requireLibrary("ktor.serialization.kotlinx.json"))
-    commonMainImplementation(libs.requireLibrary("ktor.client.content.negotiation"))
-    commonMainImplementation(libs.requireLibrary("ktor.client.mock"))
-    commonMainImplementation(libs.requireLibrary("androidx.datastore"))
-    commonMainImplementation(libs.requireLibrary("androidx.datastore.preferences"))
-}
-
-private fun VersionCatalog.requireLibrary(alias: String): Provider<MinimalExternalModuleDependency> =
-    findLibrary(alias).orElseThrow {
-        IllegalArgumentException("Library '$alias' is not defined in the version catalog.")
-    }
-
-private fun DependencyHandlerScope.commonMainImplementation(dependency: Any) {
-    add("commonMainImplementation", dependency)
-}
-
-private fun DependencyHandlerScope.androidMainImplementation(dependency: Any) {
-    add("androidMainImplementation", dependency)
-}
-
-private fun DependencyHandlerScope.iosMainImplementation(dependency: Any) {
-    add("iosMainImplementation", dependency)
-}
-
-private fun DependencyHandlerScope.commonTestImplementation(dependency: Any) {
-    add("commonTestImplementation", dependency)
-}
-
-private fun DependencyHandlerScope.debugImplementation(dependency: Any) {
-    add("debugImplementation", dependency)
 }

--- a/build-logic/convention/src/main/kotlin/my/id/tasius/dailysleeptracker/buildlogic/ConventionExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/my/id/tasius/dailysleeptracker/buildlogic/ConventionExtensions.kt
@@ -1,0 +1,141 @@
+package my.id.tasius.dailysleeptracker.buildlogic
+
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.gradle.LibraryExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.provider.Provider
+import org.gradle.kotlin.dsl.DependencyHandlerScope
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.compose.ComposePlugin
+import org.jetbrains.compose.ExperimentalComposeLibrary
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+internal fun Project.configureKotlinMultiplatform(frameworkName: String = name) {
+    extensions.configure<KotlinMultiplatformExtension> {
+        applyDefaultHierarchyTemplate()
+
+        androidTarget {
+            compilerOptions {
+                jvmTarget.set(JvmTarget.JVM_11)
+            }
+        }
+
+        listOf(
+            iosArm64(),
+            iosSimulatorArm64(),
+        ).forEach { iosTarget ->
+            iosTarget.binaries.framework {
+                baseName = frameworkName
+                isStatic = true
+            }
+        }
+    }
+}
+
+internal fun CommonExtension<*, *, *, *, *, *>.configureAndroidCommonOptions() {
+    compileOptions.sourceCompatibility = JavaVersion.VERSION_11
+    compileOptions.targetCompatibility = JavaVersion.VERSION_11
+}
+
+internal fun Project.configureAndroidLibrary() {
+    extensions.configure<LibraryExtension> {
+        val compileSdkVersion = versionInt("android-compileSdk")
+        val minSdkVersion = versionInt("android-minSdk")
+
+        compileSdk = compileSdkVersion
+        defaultConfig {
+            minSdk = minSdkVersion
+        }
+
+        configureAndroidCommonOptions()
+    }
+}
+
+internal fun Project.versionInt(key: String): Int =
+    libs.findVersion(key).orElseThrow {
+        IllegalArgumentException("Version '$key' is not defined in the version catalog.")
+    }.requiredVersion.toInt()
+
+@OptIn(ExperimentalComposeLibrary::class)
+internal fun DependencyHandlerScope.addComposeUiDependencies(
+    composeDependencies: ComposePlugin.Dependencies,
+    libs: VersionCatalog,
+) {
+    commonMainImplementation(composeDependencies.runtime)
+    commonMainImplementation(composeDependencies.foundation)
+    commonMainImplementation(composeDependencies.material3)
+    commonMainImplementation(composeDependencies.ui)
+    commonMainImplementation(composeDependencies.components.resources)
+    commonMainImplementation(composeDependencies.components.uiToolingPreview)
+    commonMainImplementation(libs.requireLibrary("androidx.lifecycle.viewmodelCompose"))
+    commonMainImplementation(libs.requireLibrary("androidx.lifecycle.runtimeCompose"))
+}
+
+internal fun DependencyHandlerScope.addFeatureDependencies(libs: VersionCatalog) {
+    commonMainImplementation(libs.requireLibrary("androidx.navigation.compose"))
+}
+
+internal fun DependencyHandlerScope.addKoinComposeDependencies(libs: VersionCatalog) {
+    commonMainImplementation(libs.requireLibrary("koin.core"))
+    commonMainImplementation(libs.requireLibrary("koin.androidx.compose"))
+}
+
+internal fun DependencyHandlerScope.addKoinCoreDependencies(libs: VersionCatalog) {
+    commonMainImplementation(libs.requireLibrary("koin.core"))
+}
+
+internal fun DependencyHandlerScope.addImageLoadingDependencies(libs: VersionCatalog) {
+    commonMainImplementation(libs.requireLibrary("coil.compose"))
+    commonMainImplementation(libs.requireLibrary("coil.network.ktor3"))
+}
+
+internal fun DependencyHandlerScope.addNetworkingDependencies(libs: VersionCatalog) {
+    commonMainImplementation(libs.requireLibrary("ktor.client.core"))
+    commonMainImplementation(libs.requireLibrary("ktor.serialization.kotlinx.json"))
+    commonMainImplementation(libs.requireLibrary("ktor.client.content.negotiation"))
+    commonMainImplementation(libs.requireLibrary("ktor.client.mock"))
+    commonMainImplementation(libs.requireLibrary("kotlinx.serialization.json"))
+}
+
+internal fun DependencyHandlerScope.addDataStoreDependencies(libs: VersionCatalog) {
+    commonMainImplementation(libs.requireLibrary("androidx.datastore"))
+    commonMainImplementation(libs.requireLibrary("androidx.datastore.preferences"))
+}
+
+internal fun DependencyHandlerScope.addKotlinTestDependencies(libs: VersionCatalog) {
+    commonTestImplementation(libs.requireLibrary("kotlin.test"))
+}
+
+internal fun DependencyHandlerScope.addKtorPlatformDependencies(libs: VersionCatalog) {
+    androidMainImplementation(libs.requireLibrary("ktor.client.okhttp"))
+    iosMainImplementation(libs.requireLibrary("ktor.client.darwin"))
+}
+
+internal fun VersionCatalog.requireLibrary(alias: String): Provider<MinimalExternalModuleDependency> =
+    findLibrary(alias).orElseThrow {
+        IllegalArgumentException("Library '$alias' is not defined in the version catalog.")
+    }
+
+internal fun DependencyHandlerScope.commonMainImplementation(dependency: Any) {
+    add("commonMainImplementation", dependency)
+}
+
+internal fun DependencyHandlerScope.androidMainImplementation(dependency: Any) {
+    add("androidMainImplementation", dependency)
+}
+
+internal fun DependencyHandlerScope.iosMainImplementation(dependency: Any) {
+    add("iosMainImplementation", dependency)
+}
+
+internal fun DependencyHandlerScope.commonTestImplementation(dependency: Any) {
+    add("commonTestImplementation", dependency)
+}
+
+internal fun DependencyHandlerScope.debugImplementation(dependency: Any) {
+    add("debugImplementation", dependency)
+}

--- a/build-logic/convention/src/main/kotlin/my/id/tasius/dailysleeptracker/buildlogic/CoreConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/my/id/tasius/dailysleeptracker/buildlogic/CoreConventionPlugin.kt
@@ -1,0 +1,31 @@
+package my.id.tasius.dailysleeptracker.buildlogic
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+class CoreConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply {
+            apply("com.android.library")
+            apply("org.jetbrains.kotlin.multiplatform")
+            apply("org.jetbrains.kotlin.plugin.serialization")
+        }
+
+        configureKotlinMultiplatform(frameworkName = name)
+        configureAndroidLibrary()
+        configureCoreDependencies()
+    }
+}
+
+private fun Project.configureCoreDependencies() {
+    val libs = libs
+
+    dependencies {
+        addNetworkingDependencies(libs)
+        addDataStoreDependencies(libs)
+        addKoinCoreDependencies(libs)
+        addKotlinTestDependencies(libs)
+        addKtorPlatformDependencies(libs)
+    }
+}

--- a/build-logic/convention/src/main/kotlin/my/id/tasius/dailysleeptracker/buildlogic/FeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/my/id/tasius/dailysleeptracker/buildlogic/FeatureConventionPlugin.kt
@@ -1,0 +1,38 @@
+package my.id.tasius.dailysleeptracker.buildlogic
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+import org.jetbrains.compose.ComposeExtension
+
+class FeatureConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply {
+            apply("com.android.library")
+            apply("org.jetbrains.kotlin.multiplatform")
+            apply("org.jetbrains.compose")
+            apply("org.jetbrains.kotlin.plugin.compose")
+            apply("org.jetbrains.kotlin.plugin.serialization")
+        }
+
+        configureKotlinMultiplatform(frameworkName = name)
+        configureAndroidLibrary()
+        configureFeatureDependencies()
+    }
+}
+
+private fun Project.configureFeatureDependencies() {
+    val composeExtension = extensions.getByName("compose") as ComposeExtension
+    val composeDependencies = composeExtension.dependencies
+    val libs = libs
+
+    dependencies {
+        addComposeUiDependencies(composeDependencies, libs)
+        addFeatureDependencies(libs)
+        addImageLoadingDependencies(libs)
+        addKoinComposeDependencies(libs)
+        addKotlinTestDependencies(libs)
+        debugImplementation(composeDependencies.uiTooling)
+        androidMainImplementation(composeDependencies.preview)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,3 +72,5 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dailysleeptracker-composeapp = { id = "dailysleeptracker.composeapp" }
+dailysleeptracker-feature = { id = "dailysleeptracker.feature" }
+dailysleeptracker-core = { id = "dailysleeptracker.core" }


### PR DESCRIPTION
## Summary
- extract shared multiplatform and dependency helpers into reusable build-logic utilities
- add dedicated feature and core convention plugins and register their plugin ids
- update the compose app convention to use the shared helpers and reorganized dependency groups

## Testing
- ./gradlew help

------
https://chatgpt.com/codex/tasks/task_e_68ddf97ef27c8328890921a77e8d4b94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Streamlined build configuration with new conventions for core and feature modules.
  - Centralized dependency management for networking, datastore, DI, Compose UI, and testing.
  - Standardized Android and multiplatform setup for more consistent builds.
- Refactor
  - Consolidated and simplified Gradle configuration to reduce duplication.
  - Replaced scattered dependency declarations with unified helpers.
- Impact
  - No user-facing changes; expect more reliable, maintainable, and faster builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->